### PR TITLE
Only register the merit:/ handler when we are in a cordova app.

### DIFF
--- a/lightwallet/src/js/services/openURL.js
+++ b/lightwallet/src/js/services/openURL.js
@@ -83,7 +83,9 @@ angular.module('copayApp.services').factory('openURLService', function($rootScop
 
       if (navigator.registerProtocolHandler) {
         $log.debug('Registering Browser handlers base:' + base);
-        navigator.registerProtocolHandler('merit', url, 'Copay Merit Handler');
+        if ('cordova' in window) {
+          navigator.registerProtocolHandler('merit', url, 'Copay Merit Handler');
+        }
         navigator.registerProtocolHandler('web+copay', url, 'Copay Wallet Handler');
         navigator.registerProtocolHandler('web+bitpay', url, 'BitPay Wallet Handler');
       }


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler.