### PR TITLE
Improvement - speed up mobile contacts searching

### DIFF
--- a/lightwallet/src/js/controllers/tab-send.js
+++ b/lightwallet/src/js/controllers/tab-send.js
@@ -3,7 +3,7 @@
 angular.module('copayApp.controllers').controller('tabSendController', function($scope, $rootScope, $log, $timeout, $ionicScrollDelegate, addressbookService, profileService, lodash, $state, walletService, incomingData, popupService, platformInfo, bwcError, gettextCatalog, scannerService) {
 
   var originalList;
-  var mobileContactList;
+  var deviceContactList;
   var CONTACTS_SHOW_LIMIT;
   var currentContactsPage;
   $scope.isChromeApp = platformInfo.isChromeApp;
@@ -118,12 +118,12 @@ angular.module('copayApp.controllers').controller('tabSendController', function(
     });
   };
 
-  var initMobileContacts = function(cb) {
-    addressbookService.getAllMobileContacts(function(contacts) {
+  var initDeviceContacts = function(cb) {
+    addressbookService.getAllDeviceContacts(function(contacts) {
       contacts = lodash.filter(contacts, function(contact) {
         return !(lodash.isEmpty(contact.emails) && lodash.isEmpty(contact.phoneNumbers));
       });
-      mobileContactList = mobileContactList.concat(lodash.map(contacts, function(contact) {
+      deviceContactList = deviceContactList.concat(lodash.map(contacts, function(contact) {
         var item = {
           name: contact.name.formatted,
           emails: lodash.map(contact.emails, function(o) { return o.value; }),
@@ -233,9 +233,9 @@ angular.module('copayApp.controllers').controller('tabSendController', function(
     }
 
     var result = findMatchingContacts(originalList, search);
-    var mobileResult = findMatchingContacts(mobileContactList, search);
+    var deviceResult = findMatchingContacts(deviceContactList, search);
 
-    $scope.list = result.concat(lodash.map(mobileResult, function(contact) {
+    $scope.list = result.concat(lodash.map(deviceResult, function(contact) {
       return contactWithSendMethod(contact, search);
     }));
   };
@@ -282,7 +282,7 @@ angular.module('copayApp.controllers').controller('tabSendController', function(
       search: null
     };
     originalList = [];
-    mobileContactList = [];
+    deviceContactList = [];
     CONTACTS_SHOW_LIMIT = 10;
     currentContactsPage = 0;
     hasWallets();
@@ -296,7 +296,7 @@ angular.module('copayApp.controllers').controller('tabSendController', function(
     updateHasFunds();
     updateWalletsList();
     initContactsList(function() {
-      initMobileContacts(function() {
+      initDeviceContacts(function() {
         initList();
       });
     });

--- a/lightwallet/src/js/services/addressbookService.js
+++ b/lightwallet/src/js/services/addressbookService.js
@@ -45,7 +45,7 @@ angular.module('copayApp.services').factory('addressbookService', function(bitco
     return cb();
   };
 
-  root.getAllMobileContacts = function(cb) {
+  root.getAllDeviceContacts = function(cb) {
     return root.searchContacts('', cb);
   };
 


### PR DESCRIPTION
This branch provides improvements to the device contacts searching on the lightwallet send page.

1. On entering the send page for the first time, get permission to access device contacts. This prevents a bug which caused the app to crash when typing in a search term too quickly before getting permission to search contacts.
2. Lightwallet now holds all contacts with either an email or phone number in memory while on the tab-send page. This allows for a much faster and more responsive search.