### PR TITLE
Typescript fails compilation in contact builder.

### DIFF
--- a/packages/lw-2/src/app/shared/address-book/merit-contact.builder.ts
+++ b/packages/lw-2/src/app/shared/address-book/merit-contact.builder.ts
@@ -43,7 +43,10 @@ export class MeritContactBuilder {
     created.phoneNumbers = clone(contact.phoneNumbers) || [];
     created.emails = clone(contact.emails) || [];
     created.photos = clone(contact.photos) || [];
-    created.meritAddresses = clone(contact.meritAddresses) || [];
+
+    if(contact instanceof MeritContact) {
+      created.meritAddresses = clone(contact.meritAddresses) || [];
+    }
 
     return created;
   }


### PR DESCRIPTION
 IContactProperties does not have a merit address.