### PR TITLE
ngx-clipboard package version fix

### DIFF
--- a/packages/lw-2/package.json
+++ b/packages/lw-2/package.json
@@ -85,7 +85,7 @@
     "ionicons": "3.0.0",
     "json-stable-stringify": "^1.0.0",
     "mkpath": "^1.0.0",
-    "ngx-clipboard": "^8.1.1",
+    "ngx-clipboard": "^9.0.0",
     "node-version-compare": "^1.0.1",
     "phonegap-plugin-barcodescanner": "^6.0.8",
     "plist": "^2.1.0",


### PR DESCRIPTION
fixed version of ngx-clipboard package, which causes 'ngx-window-token' problem