### PR TITLE
Sanitize and handle invalid mnemonic master key.

### DIFF
--- a/packages/lw-2/src/app/vaults/renew-vault/confirmation/confirmation.html
+++ b/packages/lw-2/src/app/vaults/renew-vault/confirmation/confirmation.html
@@ -15,7 +15,7 @@
         </ion-item>
 
         <ion-item>
-            <ion-textarea [placeholder]="'You have to use your old master key'" [(ngModel)]="formData.masterKey"></ion-textarea>
+            <ion-textarea [placeholder]="'You have to use your old master key'" [(ngModel)]="formData.masterKeyMnemonic"></ion-textarea>
         </ion-item>
     </ion-list>
 

--- a/packages/lw-2/src/app/vaults/renew-vault/confirmation/confirmation.ts
+++ b/packages/lw-2/src/app/vaults/renew-vault/confirmation/confirmation.ts
@@ -10,6 +10,8 @@ import { ProfileService } from 'merit/core/profile.service';
 import { RenewVaultService } from 'merit/vaults/renew-vault/renew-vault.service';
 import { Credentials } from 'src/lib/merit-wallet-client/lib/credentials';
 import { MeritWalletClient } from 'src/lib/merit-wallet-client';
+import { MeritToastController } from "merit/core/toast.controller";
+import { ToastConfig } from "merit/core/toast.config";
 
 @IonicPage({
   segment: 'vault/:vaultId/renew/confirmation',
@@ -21,40 +23,58 @@ import { MeritWalletClient } from 'src/lib/merit-wallet-client';
 })
 export class VaultRenewConfirmationView {
 
-    private updatedVault: any;
-    private vault: any;
-    private bitcore: any;
-    private formData = { masterKey: '' };
-    private walletClient: MeritWalletClient = null;
+  private updatedVault: any;
+  private vault: any;
+  private bitcore: any;
+  private formData = { masterKeyMnemonic: '' };
+  private walletClient: MeritWalletClient = null;
 
-    constructor(
-        private navCtrl:NavController,
-        public navParams: NavParams,
-        private bwc: BwcService,  
-        private renewVaultService: RenewVaultService,
-    ){
-      this.updatedVault = this.navParams.get('updatedVault');
-      this.vault = this.navParams.get('vault');
-      this.bitcore = this.bwc.getBitcore();
-      this.walletClient = this.navParams.get('walletClient');
+  constructor(
+    private navCtrl:NavController,
+    public navParams: NavParams,
+    private bwc: BwcService,  
+    private toastCtrl:MeritToastController,
+    private renewVaultService: RenewVaultService,
+  ){
+    this.updatedVault = this.navParams.get('updatedVault');
+    this.vault = this.navParams.get('vault');
+    this.bitcore = this.bwc.getBitcore();
+    this.walletClient = this.navParams.get('walletClient');
+  }
+
+  ionViewDidLoad() {
+    console.log('confirmation view', this.updatedVault, this.vault);
+  }
+
+  private sanatizeMnemonic(rawmnemonic: string): string{
+    let trimmed = rawmnemonic.trim();
+    return trimmed.toLowerCase();
+  }
+
+  private renew() {
+    // create master key from mnemonic
+    const network = this.vault.address.network;
+
+    //validate mnemonic
+    let masterKeyMnemonic;
+    try {
+      const sanatizedMasterKeyMnemonic = this.sanatizeMnemonic(this.formData.masterKeyMnemonic);
+      masterKeyMnemonic = this.walletClient.getNewMnemonic(sanatizedMasterKeyMnemonic);
+    } catch(ex) {
+      return this.toastCtrl.create({
+        message: 'The master key must only contain words seperated by spaces.',
+        cssClass: ToastConfig.CLASS_ERROR
+      }).present();
     }
 
-    ionViewDidLoad() {
-        console.log('confirmation view', this.updatedVault, this.vault);
-    }
+    const xMasterKey = masterKeyMnemonic.toHDPrivateKey('', network);
+    console.log('xMasterKey', xMasterKey);
+    console.log('MasterPub', xMasterKey.publicKey.toString());
+    console.log('OrigPubKey', new this.bitcore.PublicKey(this.updatedVault.masterPubKey, network).toString());
 
-    private renew() {
-        // create master key from mnemonic
-        const network = this.vault.address.network;
-        const masterKeyMnemonic = this.walletClient.getNewMnemonic(this.formData.masterKey);
-        const xMasterKey = masterKeyMnemonic.toHDPrivateKey('', network);
-        console.log('xMasterKey', xMasterKey);
-        console.log('MasterPub', xMasterKey.publicKey.toString());
-        console.log('OrigPubKey', new this.bitcore.PublicKey(this.updatedVault.masterPubKey, network).toString());
-       
-        return this.renewVaultService.renewVault(this.updatedVault, xMasterKey).then(() => {
-            this.navCtrl.push('VaultDetailsView', { vaultId: this.vault._id, vault: this.vault });
-            return;
-        });
-    }
+    return this.renewVaultService.renewVault(this.updatedVault, xMasterKey).then(() => {
+      this.navCtrl.push('VaultDetailsView', { vaultId: this.vault._id, vault: this.vault });
+      return;
+    });
+  }
 }


### PR DESCRIPTION
When renewing a vault, if you put in a mnemonic that was invalid, a nasty
looking error message would show up. This commit sanitizes the mnemonic input
by lowercase and trimming whitespace. If there are invalid characters, a toast
messages pops up telling the user to fix the mnemonic.