### PR TITLE
Removing IPs from cordova config.

### DIFF
--- a/packages/lw-2/config.xml
+++ b/packages/lw-2/config.xml
@@ -85,9 +85,6 @@
         <ios-team-release value="MLJ7SU96NS" />
     </branch-config>
     <content src="index.html" />
-    <allow-navigation href="http://192.168.0.3:8100" />
-    <allow-navigation href="http://192.168.1.207:8100" />
-    <allow-navigation href="http://192.168.1.110:8100" />
     <engine name="android" spec="6.4.0" />
     <engine name="ios" spec="^4.5.4" />
     <plugin name="cordova-plugin-x-socialsharing" spec="^5.2.1" />


### PR DESCRIPTION
IPs used during debugging are no longer needed.