### PR TITLE
Make sure export wallet works on ios and android devices

### DIFF
--- a/packages/lw-2/src/app/wallets/export-wallet/export-wallet.html
+++ b/packages/lw-2/src/app/wallets/export-wallet/export-wallet.html
@@ -38,7 +38,7 @@
 
             <div class="control-buttons" margin>
                 <button ion-button [disabled]="!saveEnabled()" translate (click)="download()">
-                    Download
+                    Export
                 </button>
             </div>
 

--- a/packages/lw-2/src/app/wallets/export-wallet/export-wallet.module.ts
+++ b/packages/lw-2/src/app/wallets/export-wallet/export-wallet.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
 import { ExportWalletView } from './export-wallet';
 import { QRCodeModule } from 'angular2-qrcode';
+import { File } from '@ionic-native/file';
 
 
 @NgModule({
@@ -12,5 +13,8 @@ import { QRCodeModule } from 'angular2-qrcode';
     QRCodeModule, 
     IonicPageModule.forChild(ExportWalletView),
   ],
+  providers: [
+    File,
+  ]
 })
 export class $$moduleName$$Module {}


### PR DESCRIPTION
Exporting wallets to a file was not working on android and ios devices. 
This commit uses ionic's native file plugin to save the wallet to a file on the device.