### PR TITLE
Use the wallet's master address to get ANV instead of hdpubkeys.

### DIFF
--- a/packages/lw-2/src/app/wallets/wallet.service.ts
+++ b/packages/lw-2/src/app/wallets/wallet.service.ts
@@ -1385,15 +1385,12 @@ export class WalletService {
    */
   public getANV(wallet: MeritWalletClient):Promise<any> {
     return new Promise((resolve, reject) => {
-      return this.getMainAddresses(wallet).then((addresses) => {
-        if (_.isEmpty(addresses)) {
-          this.logger.info("Addresses are empty!  Defaulting ANV to Zero");
-          return resolve(0);
-        }
-        return wallet.getANV(addresses).then((anv) => {
-          return resolve(anv);
-        })
-      });
+      let bitcore = this.bwcService.getBitcore();
+      let pubkey = bitcore.PrivateKey.fromString(wallet.credentials.walletPrivKey).toPublicKey();
+      let address = pubkey.toAddress(wallet.credentials.network);
+      return wallet.getANV(address).then((anv) => {
+        return resolve(anv);
+      })
     });
   }
 


### PR DESCRIPTION
Since all hdpubkeys are referred by the master address, just using
the wallet's pub key is enough to get correct ANV.