### PR TITLE
MWS, blockchainmonitor: TypeError: Cannot read property 'some' of undefined

### DIFF
--- a/packages/bitcore-wallet-service/lib/blockchainmonitor.js
+++ b/packages/bitcore-wallet-service/lib/blockchainmonitor.js
@@ -206,7 +206,7 @@ BlockchainMonitor.prototype._handleIncomingPayments = function(data, network) {
     //checking if address is confirmed
     explorer.getUtxos([out.address], true, function(err, utxos) {
 
-        const isAddressConfirmed = utxos.some(u => u.isInvite);
+        const isAddressConfirmed = _.some(utxos, u => u.isInvite);
 
         self.storage.fetchAddress(out.address, function(err, address) {
           if (err) {


### PR DESCRIPTION
It's supposed to fix this:
```
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:  WARN Insight http://127.0.0.1:3001/insight-api/addrs/utxo Returned Status: 400
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:  [2018-04-09T14:05:58.947Z] error: uncaught exception: TypeError: Cannot read property 'some' of undefined
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainmonitor.js:209:42
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainexplorers/insight.js:63:47
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainexplorers/request-list.js:57:14
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/async/dist/async.js:958:16
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at next (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/async/dist/async.js:5211:18)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request._callback (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainexplorers/request-list.js:52:16)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request.self.callback (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/request/request.js:186:22)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at emitTwo (events.js:126:13)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request.emit (events.js:214:7)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request.<anonymous> (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/request/request.js:1163:10)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:  [2018-04-09T14:05:58.948Z] error: TypeError: Cannot read property 'some' of undefined
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainmonitor.js:209:42
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainexplorers/insight.js:63:47
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainexplorers/request-list.js:57:14
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at /home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/async/dist/async.js:958:16
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at next (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/async/dist/async.js:5211:18)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request._callback (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/lib/blockchainexplorers/request-list.js:52:16)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request.self.callback (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/request/request.js:186:22)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at emitTwo (events.js:126:13)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request.emit (events.js:214:7)
Apr 09 17:05:59 merit-mws-node-Europe-1 bash:      at Request.<anonymous> (/home/merit/lightwallet-stack/packages/bitcore-wallet-service/node_modules/request/request.js:1163:10)
```

to see the actual fix: https://github.com/meritlabs/lightwallet-stack/pull/578/files?w=1