### PR TITLE
Adding retry logic to GetTx to avoid global races.

### DIFF
--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -2555,22 +2555,22 @@ WalletService.prototype.getTx = function(opts, cb) {
     opts.retries = 1;
   } 
 
-  async.retry({times: opts.retries, interval: 100}, 
-    self.storage.fetchTx(self.walletId, opts.txProposalId),
-      function(err, txp) {
-        if (err) return cb(err);
-        if (!txp) return cb(Errors.TX_NOT_FOUND);
+  async.retry({times: opts.retries, interval: 50}, 
+    (callback)=> {self.storage.fetchTx(self.walletId, opts.txProposalId, callback)},
+    function(err, txp) {
+      if (err) return cb(err);
+      if (!txp) return cb(Errors.TX_NOT_FOUND);
 
-        if (!txp.txid) return cb(null, txp);
+      if (!txp.txid) return cb(null, txp);
 
-        self.storage.fetchTxNote(self.walletId, txp.txid, function(err, note) {
-          if (err) {
-            log.warn('Error fetching tx note for ' + txp.txid);
-          }
-          txp.note = note;
-          return cb(null, txp);
-        });
-    });
+      self.storage.fetchTxNote(self.walletId, txp.txid, function(err, note) {
+        if (err) {
+          log.warn('Error fetching tx note for ' + txp.txid);
+        }
+        txp.note = note;
+        return cb(null, txp);
+      });
+  });
 };
 
 /**
@@ -2757,7 +2757,7 @@ WalletService.prototype.signTx = function(opts, cb) {
     */
     self.getTx({
       txProposalId: opts.txProposalId,
-      retries: 5
+      retries: 10
     }, function(err, txp) {
       if (err) return cb(err);
     


### PR DESCRIPTION
With a globally distributed mongo cluster, we could end up in a situation where a TxProposal was written to the Primary Mongo instance, but has not yet propogated to the secondary node we are reading from.

So, in this PR, I've added some retry logic.  This isn't a long-term solution, and should be reconsidered either when we the time is right.

I'm not convinced that re-doing so much logic in JS that already exists in CPP is the right long-term solution anyway.  I'd like to see an MWS approach that converges with the notion of MasterNodes.

In any case, we shouldn't do more than the simplest solution that reliably fixes the problem for now.  Downstream, based on our larger architectural picture, we can address this.