### PR TITLE
[DLW] Remove copy link from wallet list

### DIFF
--- a/packages/lightwallet/desktop/src/app/core/components/wallets-list/wallets-list.component.html
+++ b/packages/lightwallet/desktop/src/app/core/components/wallets-list/wallets-list.component.html
@@ -35,9 +35,6 @@
           <div class="inline-right">
             <div class="controls">
               <p class="invites regular-blue-text">{{ wallet?.availableInvites || 0 }} Invites</p>
-              <p class="share-link" [clip]="shareLink(wallet)" [title]="shareLink(wallet)" (click)="onCopy($event, wallet.id)">
-                Copy share link
-              </p>
             </div>
             <merit-icon name="right-arrow"></merit-icon>
           </div>


### PR DESCRIPTION
1. It looks better without it.. there's not much room in the wallet list item for this link
2. The link did not look like it was clickable since it has the same font + color as everything else