### PR TITLE
Multiple notifications

### DIFF
--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -519,11 +519,11 @@ Storage.prototype.fetchNotifications = function(walletId, notificationId, minTs,
       id: {
         $gt: minId,
       },
-    })
-    .sort({
+    }, {
+      readPreference: mongodb.ReadPreference.PRIMARY,
+    }).sort({
       id: 1
-    })
-    .toArray(function(err, result) {
+    }).toArray(function(err, result) {
       if (err) return cb(err);
       if (!result) return cb();
       var notifications = _.map(result, function(notification) {


### PR DESCRIPTION
Multiple notifications are sent to clients. 
Possible reason - delay in replications of Mongo cluster.