### PR TITLE
Prevent duplicate wallet creation

### DIFF
--- a/packages/lightwallet/desktop/src/app/onboarding/unlock/unlock.view.ts
+++ b/packages/lightwallet/desktop/src/app/onboarding/unlock/unlock.view.ts
@@ -98,6 +98,11 @@ export class UnlockComponent {
   }
 
   async onSubmit() {
+    if (this.creatingWallet) {
+      // prevent duplicate submissions
+      return;
+    }
+
     this.loadingCtrl.show();
     this.creatingWallet = true;
     let { inviteCode, alias } = this.formData.getRawValue();


### PR DESCRIPTION
Loading spinner takes a second to show up. In some cases the user might click on the button more than once, thinking it didn't work the first time.