### PR TITLE
Enlarge constant to fix error "Transaction too large"

### DIFF
--- a/packages/bitcore-wallet-service/lib/common/defaults.js
+++ b/packages/bitcore-wallet-service/lib/common/defaults.js
@@ -6,7 +6,7 @@ Defaults.MIN_FEE_PER_KB = 0;
 Defaults.MAX_FEE_PER_KB = 1000000;
 Defaults.MIN_TX_FEE = 0;
 Defaults.MAX_TX_FEE = 0.1 * 1e8;
-Defaults.MAX_TX_SIZE_IN_KB = 1000;
+Defaults.MAX_TX_SIZE_IN_KB = 6000;
 
 Defaults.MAX_KEYS = 100;
 


### PR DESCRIPTION
value the same as for meritd (third of block size)