### PR TITLE
Fix crash when result is not checked

### DIFF
--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -1457,7 +1457,8 @@ Storage.prototype.checkKnownMessages = function (data, cb) {
     returnOriginal: false,
     upsert: true,
   }, function (err, result) {
-    cb(err, result.lastErrorObject && result.lastErrorObject.updatedExisting && result.value && result.ok);
+    if (err) return cb(err);
+    return cb(null, result && result.lastErrorObject && result.lastErrorObject.updatedExisting && result.value && result.ok);
   });
 };
 


### PR DESCRIPTION
```
error: uncaught exception: TypeError: Cannot read property 'lastErrorObject' of null
    at lightwallet-stack/packages/bitcore-wallet-service/lib/storage.js:1460:20
```