### PR TITLE
Some performance improvements.

### DIFF
--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -802,12 +802,21 @@ WalletService.prototype.getStatus = function(opts, cb) {
           });
         },
         function(next) {
+          status.pendingTxps = [];
+          next();
+          /**
+           * Depecrating geting pending Txps in the get status call since 
+           * the pendingTxps are literally  not used by the LW code yet.
+           * In any case, if any code needs pendingTxps, they can get it
+           * via the api call. The getStatus needs to be fast.
+            
           self.getPendingTxs({}, function(err, pendingTxps) {
             if (err) return next(err);
             status.pendingTxps = pendingTxps;
 
             next();
           });
+          */
         },
         function(next) {
           self.getPreferences({}, function(err, preferences) {
@@ -4562,7 +4571,9 @@ WalletService.prototype.getCommunityRanks = async function(addresses, cb) {
 WalletService.prototype.getCommunityLeaderboard = async function(limit, cb) {
   try {
     limit = limit || 100;
-    const result = await localMeritDaemon.getCommunityLeaderboard(limit);
+    //pull directly from mongodb. How the data in mongodb is updated is 
+    //outside of MWS. Likely a cron job that runs every once in a while.
+    const result = await promisify(this.storage.getLeaderboard.bind(this.storage))(limit);
     return cb(null, result);
   } catch (e) {
     if (typeof e === 'object' && e.code) {

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -36,6 +36,7 @@ var collections = {
   SMS_NOTIFICATION_SUBS: 'sms_notification_subs',
   GLOBALSENDS: 'global_sends',
   KNOWN_MESSAGES: 'known_messages',
+  LEADERBOARD: 'leaderboard',
 };
 
 var Storage = function (opts) {
@@ -1459,6 +1460,16 @@ Storage.prototype.checkKnownMessages = function (data, cb) {
   }, function (err, result) {
     if (err) return cb(err);
     return cb(null, result && result.lastErrorObject && result.lastErrorObject.updatedExisting && result.value && result.ok);
+  });
+};
+
+Storage.prototype.getLeaderboard = function (limit, cb) {
+  this.db.collection(collections.LEADERBOARD).findOne({
+    limit: parseInt(limit), 
+  }, function (err, result) {
+    if (err) return cb(err);
+    if (!result) return cb();
+    return cb(null, result);
   });
 };
 


### PR DESCRIPTION
1. Don't get pending txps in getStatus.
2. Don't call getaddressleaderboard from meritd. Use cached data in mongo.