### PR TITLE
Disabling the startup tracker because the dialog does not disappear.

### DIFF
--- a/packages/lightwallet/desktop/src/app/core/core.component.html
+++ b/packages/lightwallet/desktop/src/app/core/core.component.html
@@ -48,5 +48,4 @@
       </div>
     </div>
   </div>
-  <app-welcome-to-setup-tracker *ngIf="isWelcomeDialogEnabled$ | async"></app-welcome-to-setup-tracker>
 </ng-template>


### PR DESCRIPTION
We will enable it once the dialog works correctly.