### PR TITLE
Explicitly specify https in addthis link

### DIFF
--- a/packages/lightwallet/desktop/src/index.html
+++ b/packages/lightwallet/desktop/src/index.html
@@ -184,7 +184,7 @@
   <div id="shareThis" style="position: fixed; left: -100%; bottom: -100%;">
     <div class="addthis_inline_share_toolbox"></div>
   </div>
-  <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5afc974bd2527af3"></script>
+  <script type="text/javascript" src="https://s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5afc974bd2527af3"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This is required to make it work in Electron

Closes #1007